### PR TITLE
use instances, not type objects, for actions

### DIFF
--- a/src/slides-day1.md
+++ b/src/slides-day1.md
@@ -791,7 +791,7 @@ method installed into it, by section name.
 
 The actions are passed as a named parameter to `parse`:
 
-    my $m := INIFile.parse($to_parse, :actions(INIFileActions));
+    my $m := INIFile.parse($to_parse, :actions(INIFileActions.new));
 
 The result hash can be obtained from the resulting match object using the
 `.ast`, as we already saw.
@@ -1033,7 +1033,7 @@ hash produced by the `pairlist` action method onto it.
         has @!data;
         
         method execute($query) {
-            if QueryParser.parse($query, :actions(QueryActions)) -> $parsed {
+            if QueryParser.parse($query, :actions(QueryActions.new)) -> $parsed {
                 my $evaluator := $parsed.ast;
                 if $evaluator(@!data) -> @results {
                     for @results -> %data {


### PR DESCRIPTION
while it is not strictly necessary in the cases shown,
using type objects fails as soon as you want to use attributes
in the action classes. At least it confused [Coke] during an exercise