### PR TITLE
port rubyish-3.nqp and rubyish-4.nqp to latest nqp-m.

### DIFF
--- a/examples/rubyish-2.nqp
+++ b/examples/rubyish-2.nqp
@@ -26,16 +26,14 @@ grammar Rubyish::Grammar is HLL::Grammar {
     token ws { <!ww> \h* || \h+ }
     
     # Operator precedence levels
-    INIT {
-        Rubyish::Grammar.O(':prec<u=>, :assoc<left>',  '%multiplicative');
-        Rubyish::Grammar.O(':prec<t=>, :assoc<left>',  '%additive');
-    }
+    my %multiplicative := nqp::hash('prec', 'u=', 'assoc', 'left');
+    my %additive := nqp::hash('prec', 't=', 'assoc', 'left');
     
     # Operators
-    token infix:sym<*> { <sym>  <O('%multiplicative, :op<mul_n>')> }
-    token infix:sym</> { <sym>  <O('%multiplicative, :op<div_n>')> }
-    token infix:sym<+> { <sym>  <O('%additive, :op<add_n>')> }
-    token infix:sym<-> { <sym>  <O('%additive, :op<sub_n>')> }
+    token infix:sym<*> { <sym> <O(|%multiplicative, :op<mul_n>)> }
+    token infix:sym</> { <sym> <O(|%multiplicative, :op<div_n>)> }
+    token infix:sym<+> { <sym> <O(|%additive, :op<add_n>)> }
+    token infix:sym<-> { <sym> <O(|%additive, :op<sub_n>)> }
 }
 
 class Rubyish::Actions is HLL::Actions {


### PR DESCRIPTION
1. changed interface to <O> (operator/expression) token
2. we now need to consume 'self' parameter in method invocations
3. override 'eval' method in HLL:Compiler. This is a work-around, otherwise
`% nqp-m rubyish-3.nqp rubyish-3-tests.t`, dies with:
    Too many positionals passed; expected 1 argument but got 3
       at gen/moar/stage2/NQPHLL.nqp:742  (/home/david/git/rakudo-blead/install/share/nqp/lib/NQPHLL.moarvm:O)
    from examples/rubyish-3.nqp:72  (<ephemeral file>:)
    ...