### PR TITLE
Fix exercise 5

### DIFF
--- a/solutions/exercise-5.nqp
+++ b/solutions/exercise-5.nqp
@@ -149,6 +149,11 @@ class PHPish::Actions is HLL::Actions {
 }
 
 class PHPish::Compiler is HLL::Compiler {
+    method eval($code, *@args, *%adverbs) {
+        my $output := self.compile($code, :compunit_ok(1), |%adverbs);
+        $output := self.backend.compunit_mainline($output);
+        $output();
+    }
 }
 
 sub MAIN(*@ARGS) {

--- a/solutions/exercise-5.nqp
+++ b/solutions/exercise-5.nqp
@@ -57,19 +57,17 @@ grammar PHPish::Grammar is HLL::Grammar {
     token semi    { <.ws> [ ';' || $ ] }
 
     # Operator precedence levels
-    INIT {
-        PHPish::Grammar.O(':prec<u=>, :assoc<left>', '%multiplicative');
-        PHPish::Grammar.O(':prec<t=>, :assoc<left>', '%additive');
-        PHPish::Grammar.O(':prec<j=>, :assoc<right>',  '%assignment');
-    }
+    my %multiplicative := nqp::hash('prec', 'u=', 'assoc', 'left');
+    my %additive := nqp::hash('prec', 't=', 'assoc', 'left');
+    my %assignment := nqp::hash('prec', 'i=', 'assoc', 'right');
     
     # Operators
-    token infix:sym<*> { <sym>  <O('%multiplicative, :op<mul_n>')> }
-    token infix:sym</> { <sym>  <O('%multiplicative, :op<div_n>')> }
-    token infix:sym<+> { <sym>  <O('%additive, :op<add_n>')> }
-    token infix:sym<-> { <sym>  <O('%additive, :op<sub_n>')> }
-    token infix:sym<.> { <sym>  <O('%additive, :op<concat>')> }
-    token infix:sym<=> { <sym> <O('%assignment, :op<bind>')> }
+    token infix:sym<*> { <sym>  <O(|%multiplicative, :op<mul_n>)> }
+    token infix:sym</> { <sym>  <O(|%multiplicative, :op<div_n>)> }
+    token infix:sym<+> { <sym>  <O(|%additive, :op<add_n>)> }
+    token infix:sym<-> { <sym>  <O(|%additive, :op<sub_n>)> }
+    token infix:sym<.> { <sym>  <O(|%additive, :op<concat>)> }
+    token infix:sym<=> { <sym> <O(|%assignment, :op<bind>)> }
 }
 
 class PHPish::Actions is HLL::Actions {

--- a/solutions/exercise-5.nqp
+++ b/solutions/exercise-5.nqp
@@ -39,7 +39,7 @@ grammar PHPish::Grammar is HLL::Grammar {
     token term:sym<variable> {
         :my $*MAYBE_DECL := 0;
         <varname>
-        [ <?before \s* '=' [\w | \s+] { $*MAYBE_DECL := 1 }> || <?> ]
+        [ <?before \s* '=' \s* <value> { $*MAYBE_DECL := 1 }> || <?> ]
     }
     
     token term:sym<call> {


### PR DESCRIPTION
Hi,
I found that the solution for exercise-5.nqp doesn't work and fixed some portions of the code:

+ Use `\s* <value>` instead of `\w`. (L42)
   + (NOTE: In the previous one, `$a = "abc"` doesn't work) 
+ `INIT { PHPish::Grammar.O(...) }` doesn't work. So I instead use `nqp::hash`. (L60-L70)
+ Override HLL::Compiler.eval not to call `output(|@args)`. (L152-L156)

BTW, why does HLL::Compiler.eval use `@args` as an argument of `output`?
I couldn't understand well.


