### PR TITLE
a fix for a beamer 'tightlist' error

### DIFF
--- a/tools/md2tex
+++ b/tools/md2tex
@@ -39,6 +39,15 @@ my $HEADER = <<'EOT';
 \titlegraphic{
   \includegraphics[scale=0.1]{eps/edument-logo.eps}
 }
+
+
+%%%%% THIS FIXES TIGHTLIST ERROR %%%%%
+% error occurs with some lists due to an error in some beamer files after 2015
+% add the following to fix it if needed
+\providecommand{\tightlist}{%
+  \setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}}
+%%%%% END TIGHTLIST ERROR FIX %%%%%
+
 \begin{document}
 
 %----------- titlepage ----------------------------------------------%


### PR DESCRIPTION
Sometime after I first used `md2tex` for creating pdf slides (after I upgraded to Debian 8 [Wheezy] I think), I started getting failures while generating slides that referenced "tightlist". I found reference to the errors on the net but none that worked for me.

The fixes recommended inserting this code into various `beamer` templates:

    \providecommand{\tightlist}{%
      \setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}}

That didn't work for my system and I tried it in several templates in `texlive`. Finally, I found that adding it into `md2tex` worked!

This pull request inserts that code at the proper place.

Current OS: Debian 10 (Buster)

